### PR TITLE
Add missing pieces from github repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,30 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve 🤔.
+labels: bug
+---
+
+<!-- ⚠️ If you do not respect this template, your issue will be closed -->
+<!-- ⚠️ Make sure to browse the opened and closed issues -->
+
+### Information
+
+- **Qiskit Honeywell Provider version**:
+- **Python version**:
+- **Operating system**:
+
+### What is the current behavior?
+
+
+
+### Steps to reproduce the problem
+
+
+
+### What is the expected behavior?
+
+
+
+### Suggested solutions
+
+

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT_REQUEST.md
@@ -1,0 +1,12 @@
+---
+name: 💅 Enhancement request
+about: Suggest an improvement for this project 🆒!
+labels: 'type: enhancement'
+---
+
+<!-- ⚠️ If you do not respect this template, your issue will be closed -->
+<!-- ⚠️ Make sure to browse the opened and closed issues to confirm this idea does not exist. -->
+
+### What is the expected enhancement?
+
+

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,12 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea for this project 💡!
+labels: 'type: feature request'
+---
+
+<!-- ⚠️ If you do not respect this template, your issue will be closed -->
+<!-- ⚠️ Make sure to browse the opened and closed issues to confirm this idea does not exist. -->
+
+### What is the expected behavior?
+
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+⚠️ If you do not respect this template, your pull request will be closed.
+⚠️ Your pull request title should be short detailed and understandable for all.
+⚠️ Also, please add a release note file using reno if the change needs to be
+  documented in the release notes.
+⚠️ If your pull request fixes an open issue, please link to the issue.
+
+- [ ] I have added the tests to cover my changes.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the CONTRIBUTING document.
+-->
+
+### Summary
+
+
+
+### Details and comments
+
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+---
+title: Contributor Covenant Code of Conduct
+---
+
+Our Pledge
+==========
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our
+project and our community a harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, gender identity and
+expression, level of experience, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+Our Standards
+=============
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+-   Using welcoming and inclusive language
+-   Being respectful of differing viewpoints and experiences
+-   Gracefully accepting constructive criticism
+-   Focusing on what is best for the community
+-   Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+-   The use of sexualized language or imagery and unwelcome sexual
+    attention or advances
+-   Trolling, insulting/derogatory comments, and personal or political
+    attacks
+-   Public or private harassment
+-   Publishing others\' private information, such as a physical or
+    electronic address, without explicit permission
+-   Other conduct which could reasonably be considered inappropriate in
+    a professional setting
+
+Our Responsibilities
+====================
+
+Project maintainers are responsible for clarifying the standards of
+acceptable behavior and are expected to take appropriate and fair
+corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, or to ban
+temporarily or permanently any contributor for other behaviors that they
+deem inappropriate, threatening, offensive, or harmful.
+
+Scope
+=====
+
+This Code of Conduct applies both within project spaces and in public
+spaces when an individual is representing the project or its community.
+Examples of representing a project or community include using an
+official project e-mail address, posting via an official social media
+account, or acting as an appointed representative at an online or
+offline event. Representation of a project may be further defined and
+clarified by project maintainers.
+
+Enforcement
+===========
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may
+be reported by contacting the project team at <qiskit@qiskit.org>. The
+project team will review and investigate all complaints, and will
+respond in a way that it deems appropriate to the circumstances. The
+project team is obligated to maintain confidentiality with regard to the
+reporter of an incident. Further details of specific enforcement
+policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in
+good faith may face temporary or permanent repercussions as determined
+by other members of the project\'s leadership.
+
+Attribution
+===========
+
+This Code of Conduct is adapted from the Contributor
+[Covenant](http://contributor-covenant.org),
+[version](http://contributor-covenant.org/version/1/4/) 1.4.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing
+
+First read the overall project contributing guidelines. These are all
+included in the qiskit documentation:
+
+https://qiskit.org/documentation/contributing_to_qiskit.html
+
+## Contributing to Qiskit Honeywell Provider
+
+In addition to the general guidelines there are specific details for
+contributing to the Honeywell provider, these are documented below.
+
+### Tests
+
+Once you've made a code change, it is important to verify that your change
+does not break any existing tests and that any new tests that you've added
+also run successfully. Before you open a new pull request for your change,
+you'll want to run the test suite locally.
+
+The easiest way to run the test suite is to use
+[**tox**](https://tox.readthedocs.io/en/latest/#). You can install tox
+with pip: `pip install -U tox`. Tox provides several advantages, but the
+biggest one is that it builds an isolated virtualenv for running tests. This
+means it does not pollute your system python when running. Additionally, the
+environment that tox sets up matches the CI environment more closely and it
+runs the tests in parallel (resulting in much faster execution). To run tests
+on all installed supported python versions and lint/style checks you can simply
+run `tox`. Or if you just want to run the tests once run for a specific python
+version: `tox -epy37` (or replace py37 with the python version you want to use,
+py35 or py36).
+
+If you just want to run a subset of tests you can pass a selection regex to
+the test runner. For example, if you want to run all tests that have "dag" in
+the test id you can run: `tox -epy37 -- credentials`. You can pass arguments
+directly to the test runner after the bare `--`. To see all the options on test
+selection you can refer to the stestr manual:
+https://stestr.readthedocs.io/en/stable/MANUAL.html#test-selection
+
+If you want to run a single test module, test class, or individual test method
+you can do this faster with the `-n`/`--no-discover` option. For example:
+
+to run a module:
+```
+tox -epy37 -- -n test.test_honeywell_credentials
+```
+or to run the same module by path:
+
+```
+tox -epy37 -- -n test/test_honeywell_credentials.py
+```
+to run a class:
+
+```
+tox -epy37 -- -n test.test_honeywell_credentials.TestCredentials
+```
+to run a method:
+```
+tox -epy37 -- -n test.test_honeywell_credentials.TestCredentials.test_discover_credentials_no_creds
+```
+
+##### Online Tests
+
+Some tests require that you have a Honeywell account configured. These tests
+will be skipped if no credentials are available. If you want to run these tests
+you need to have credentials configured either via the `HQS_TOKEN` environment
+variable, or via a saved account locally. If you do not want to run these tests
+but have configured credentials you can set the `QISKIT_TEST_SKIP_ONLINE` to
+`True` (or `1`) and the online tests will also be skipped.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ tox -epy37 -- -n test.test_honeywell_credentials.TestCredentials.test_discover_c
 
 Some tests require that you have a Honeywell account configured. These tests
 will be skipped if no credentials are available. If you want to run these tests
-you need to have credentials configured either via the `HQS_TOKEN` environment
+you need to have credentials configured either via the `HQS_API_KEY` environment
 variable, or via a saved account locally. If you do not want to run these tests
 but have configured credentials you can set the `QISKIT_TEST_SKIP_ONLINE` to
 `True` (or `1`) and the online tests will also be skipped.


### PR DESCRIPTION
This commit adds the pieces missing from the github repo for the
project. Mainly templates for issues and pull requests, as well as the
code of conduct (which is shared across all Qiskit projects) and a
contributing guide.