### PR TITLE
Remove marshmallow import and fix exception catch

### DIFF
--- a/qiskit/providers/honeywell/honeywellbackend.py
+++ b/qiskit/providers/honeywell/honeywellbackend.py
@@ -28,8 +28,7 @@
 
 import logging
 
-from marshmallow import ValidationError
-
+from qiskit.exceptions import QiskitError
 from qiskit.providers import BaseBackend
 from qiskit.providers.models import BackendStatus
 
@@ -93,7 +92,7 @@ class HoneywellBackend(BaseBackend):
 
         try:
             return BackendStatus.from_dict(api_status)
-        except ValidationError as ex:
+        except QiskitError as ex:
             raise LookupError(
                 "Couldn't get backend status: {0}".format(ex)
             )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Right now marshmallow is not part of the honeywell provider's
requirements list, however it's being directly imported in one place and
only used for catching an exception (actually a subclass of an
exception). Terra is moving away from using marshmallow so this commit
removes the sole marshmallow import and updates the exception catch to
use the base qiskit exception class which will still work and not be
removed.

### Details and comments