### PR TITLE
Update package metadata and README for new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Qiskit Honeywell Provider
 
-[![License](https://img.shields.io/github/license/Qiskit/qiskit-honeywell-provider.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)[![Build Status](https://img.shields.io/travis/com/Qiskit/qiskit-honeywell-provider/master.svg?style=popout-square)](https://travis-ci.com/Qiskit/qiskit-honeywell-provider)[![](https://img.shields.io/github/release/Qiskit/qiskit-honeywell-provider.svg?style=popout-square)](https://github.com/Qiskit/qiskit-honeywell-provider/releases)[![](https://img.shields.io/pypi/dm/qiskit-honeywell-provider.svg?style=popout-square)](https://pypi.org/project/qiskit-honeywell-provider/)
+[![License](https://img.shields.io/github/license/qiskit-community/qiskit-honeywell-provider.svg?style=popout-square)](https://opensource.org/licenses/Apache-2.0)[![Build Status](https://img.shields.io/travis/com/qiskit-community/qiskit-honeywell-provider/master.svg?style=popout-square)](https://travis-ci.com/qiskit-community/qiskit-honeywell-provider)[![](https://img.shields.io/github/release/qiskit-community/qiskit-honeywell-provider.svg?style=popout-square)](https://github.com/qiskit-community/qiskit-honeywell-provider/releases)[![](https://img.shields.io/pypi/dm/qiskit-honeywell-provider.svg?style=popout-square)](https://pypi.org/project/qiskit-honeywell-provider/)
 
 **Qiskit** is an open-source framework for working with noisy quantum computers at the level of pulses, circuits, and algorithms.
 
@@ -64,16 +64,9 @@ result = execute(qc, backend).result()
 print(result.get_counts(qc))
 ```
 
-## Authors and Citation
-
-The Qiskit Honeywell provider is the work of many people who contribute to the
-project at different levels. If you use Qiskit, please cite as per the included
-[BibTeX file].
-
 ## License
 
 [Apache License 2.0].
 
-[BibTeX file]: https://github.com/Qiskit/qiskit/blob/master/Qiskit.bib
-[Apache License 2.0]: https://github.com/Qiskit/qiskit-honeywell-provider/blob/master/LICENSE.txt
+[Apache License 2.0]: https://github.com/qiskit-community/qiskit-honeywell-provider/blob/master/LICENSE.txt
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# This code is part of Qiskit.
+# This code is part of Qiskit
 #
 # (C) Copyright IBM 2017.
 #
@@ -53,16 +53,16 @@ setuptools.setup(
     description="Qiskit provider for accessing the quantum devices at Honeywell",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    url="https://github.com/Qiskit/qiskit-honeywell-provider",
+    url="https://github.com/qiskit-community/qiskit-honeywell-provider",
     packages=setuptools.find_namespace_packages(include=['qiskit.*']),
     install_requires=requirements,
     python_requires=">=3.5",
     include_package_data=True,
     keywords="qiskit quantum",
     project_urls={
-        "Bug Tracker": "https://github.com/Qiskit/qiskit-honeywell-provider/issues",
+        "Bug Tracker": "https://github.com/qiskit-community/qiskit-honeywell-provider/issues",
         "Documentation": "https://qiskit.org/documentation/",
-        "Source Code": "https://github.com/Qiskit/qiskit-honeywell-provider"
+        "Source Code": "https://github.com/qiskit-community/qiskit-honeywell-provider"
     },
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The qiskit github organization is in the process of being reorganized to
concentrate on the core elements, dependencies, development tools, etc. As
part of this reoganization 3rd party providers are being moved to projects
under the qiskit-community github organization. As part of this the
qiskit-honeywell-provider repository was moved to qiskit-community github
organization. This commit updates the README and package metadata to
reflect this change.

### Details and comments


