### PR TITLE
Add missing super() to test setUp() methods

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -295,7 +295,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=matplotlib.cm,numpy.random,retworkx
+ignored-modules=matplotlib.cm,numpy.random,retworkx,qiskit.providers
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/test/test_honeywellbackend.py
+++ b/test/test_honeywellbackend.py
@@ -60,6 +60,7 @@ class HoneywellBackendTestCase(QiskitTestCase):
     backend_name = 'HQS-LT-1.0-APIVAL'
 
     def setUp(self):
+        super().setUp()
         self.circuit = QuantumCircuit(4)
         self.circuit.h(0)
         self.circuit.cx(0, 1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In recent qiskit-terra releases the base test class that terra exports
for some utility methods added a strict requirement that the base
class's setUp method is always called. This was done to ensure that some
fixture tracking around logging in parallel is always run. However, one
test class was not calling super().setUp() when it defined a setUp()
method which resulted in a test failure when running tests with the
latest terra (like we do in CI). This commit fixes this issue by adding
the missing super() call.

### Details and comments