### PR TITLE
Drop Python 3.5 support and add 3.9 testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setuptools.setup(
     url="https://github.com/qiskit-community/qiskit-honeywell-provider",
     packages=setuptools.find_namespace_packages(include=['qiskit.*']),
     install_requires=requirements,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     include_package_data=True,
     keywords="qiskit quantum",
     project_urls={
@@ -73,10 +73,10 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering"
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py35, py36, py37, py38, lint
+envlist = py36, py37, py38, py39, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Upstream Python 3.5 is EoL since September 2020 and Qiskit dropped
support at roughly the same time. Therefore the honeywell provider can't
realistically maintain 3.5 support anymore. This commit drops 3.5
support and also adds testing for python 3.9, the latest version which
the rest of qiskit already supports.

### Details and comments