### PR TITLE
[Need Help] Follow the change of the new API URL.

### DIFF
--- a/qiskit/providers/honeywell/api/honeywellclient.py
+++ b/qiskit/providers/honeywell/api/honeywellclient.py
@@ -31,7 +31,7 @@ from requests.compat import urljoin
 from .session import RetrySession
 from .rest import Api
 
-_API_URL = 'https://qapi.honeywell.com'
+_API_URL = 'https://qapi.quantinuum.com'
 _API_VERSION = 'v1'
 
 


### PR DESCRIPTION
I am using Quantinuum (the successor of Honeywell) using this library.
It stopped working a while ago due to a change in the URL.

The base URL of the API is now `https://qapi.quantinuum.com` based on `https://github.com/CQCL/pytket-quantinuum/blob/332da684a192f20860badab19e8ca568f12cb94c/pytket/extensions/quantinuum/backends/api_wrappers.py#L77`.

### Summary
The `_API_URL` in `qiskit/providers/honeywell/api/honeywellclient.py` is changed to `https://qapi.quantinuum.com`.

### Details and comments
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly. ( I think this is not necessary.)
- [x] I have read the CONTRIBUTING document.
I am sorry but I don`t have any idea to add a test, because now this repository has no test to use the machine online.

I would appreciate it if you could give me some advice to add tests.
Thanks