### PR TITLE
Pin importlib-metadata in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
 pylint==2.4.4
 astroid==2.3.3
+importlib-metadata==4.13.0;python_version<'3.8'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent release of importlib-metadata broke compatibility with stevedore on Python 3.7. Stevedore is a dependency of a dependency of stestr which we use for running tests in CI so this is blocking CI from working and tests from running locally with Python 3.7. This commit pins the importlib-metadata version in CI to unblock things.


### Details and comments


