### PR TITLE
Update CI configuration and supported python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
         os: ["ubuntu-latest", "macOS-latest", "windows-latest"]
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setuptools.setup(
     url="https://github.com/qiskit-community/qiskit-quantinuum-provider",
     packages=setuptools.find_namespace_packages(include=['qiskit.*']),
     install_requires=requirements,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     include_package_data=True,
     keywords="qiskit quantum",
     project_urls={
@@ -75,10 +75,11 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering"
     ],
     zip_safe=False,

--- a/test/test_quantinuumbackend.py
+++ b/test/test_quantinuumbackend.py
@@ -64,7 +64,7 @@ class QuantinuumBackendTestCase(QiskitTestCase):
         self.circuit.h(0)
         self.circuit.cx(0, 1)
         self.circuit.h(0)
-        self.circuit.cu1(1.0, 0, 1)
+        self.circuit.cp(1.0, 0, 1)
         self.circuit.toffoli(0, 1, 2)
         self.circuit.toffoli(1, 2, 3)
         self.circuit.x(0)
@@ -86,8 +86,8 @@ class QuantinuumBackendTestCase(QiskitTestCase):
         self.circuit.crz(1.0, 0, 1)
         self.circuit.crx(1.0, 0, 1)
         self.circuit.cry(1.0, 0, 1)
-        self.circuit.cu1(1.0, 0, 1)
-        self.circuit.cu3(1.0, 2.0, 3.0, 0, 1)
+        self.circuit.cp(1.0, 0, 1)
+        self.circuit.cu(1.0, 2.0, 3.0, 0.0, 0, 1)
         self.circuit.measure_all()
 
     def test_configuration(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-minversion = 2.1
-envlist = py36, py37, py38, py39, lint
-skipsdist = True
+minversion = 4.4.0
+envlist = py37, py38, py39, py310, py311, lint
 
 [testenv]
 usedevelop = true
-install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}
+install_command = python -I -m pip install -c{toxinidir}/constraints.txt -U {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US
@@ -18,7 +17,6 @@ commands =
     stestr run {posargs}
 
 [testenv:lint]
-basepython = python3
 deps =
   pycodestyle
   pylint
@@ -30,7 +28,6 @@ commands =
   pylint -rn --rcfile={toxinidir}/.pylintrc qiskit_quantinuum test/
 
 [testenv:docs]
-basepython = python3
 deps =
     -r{toxinidir}/requirements-dev.txt
 commands =


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit makes two primary changes. The first is to update the tox usage to be compatible with tox>=4.0.0 and sets the minimum tox version to be 4.4.0 to ensure users are on a compatible tox version. This should fix CI failures we've been seeing since Decemember when tox 4.0.0 was released and broke everything. The second change is to update the supported python versions. The versions of python we support in this package needs to be expanded to cover currently supported version by the upstream Python community. Mainly 3.6 is EoL and this adds explicit support for 3.10 and 3.11. I think after the next release of this package we should also drop 3.7 support since it goes EoL this summer.

### Details and comments


