### PR TITLE
QuantinuumJob response is sometimes JobStatus

### DIFF
--- a/qiskit_quantinuum/quantinuumjob.py
+++ b/qiskit_quantinuum/quantinuumjob.py
@@ -339,17 +339,16 @@ class QuantinuumJob(JobV1):
 
                 experiment_result = {
                     'shots': self._job_config.get('shots', 1),
-                    'success': False,
+                    'success': res_resp != JobStatus.ERROR,
                     'data': {'counts': {}},
-                    'job_id': self._job_ids[i]
+                    'job_id': self._job_id
                 }
 
                 if self._circuits_job:
-                    experiment_result['header'] = {} if self._experiments[i].metadata is None
-                        else self._experiments[i].metadata
+                    experiment_result['header'] = {} if len(self._experiments) >= i or self._experiments[i].metadata is None else self._experiments[i].metadata
                 else:
-                    experiment_result['header'] =
-                        self._qobj_payload['experiments'][i]['header'] if self._qobj_payload else {}
+                    experiment_result['header'] = self._qobj_payload['experiments'][i]['header'] if self._qobj_payload else {}
+
                 results.append(experiment_result)
 
                 continue
@@ -367,11 +366,10 @@ class QuantinuumJob(JobV1):
                 'job_id': self._job_ids[i]
             }
             if self._circuits_job:
-                experiment_result['header'] = {} if self._experiments[i].metadata is None
-                    else self._experiments[i].metadata
+                experiment_result['header'] = {} if self._experiments[i].metadata is None else self._experiments[i].metadata
             else:
-                experiment_result['header'] = self._qobj_payload[
-                    'experiments'][i]['header'] if self._qobj_payload else {}
+                experiment_result['header'] = self._qobj_payload['experiments'][i]['header'] if self._qobj_payload else {}
+
             results.append(experiment_result)
 
         result = {

--- a/qiskit_quantinuum/quantinuumjob.py
+++ b/qiskit_quantinuum/quantinuumjob.py
@@ -345,9 +345,14 @@ class QuantinuumJob(JobV1):
                 }
 
                 if self._circuits_job:
-                    experiment_result['header'] = {} if len(self._experiments) >= i or self._experiments[i].metadata is None else self._experiments[i].metadata
+                    if len(self._experiments) >= i or self._experiments[i].metadata is None:
+                        metadata = {}
+                    else:
+                        metadata = self._experiments[i].metadata
+                    experiment_result['header'] = metadata
                 else:
-                    experiment_result['header'] = self._qobj_payload['experiments'][i]['header'] if self._qobj_payload else {}
+                    experiment_result['header'] = self._qobj_payload[
+                    'experiments'][i]['header'] if self._qobj_payload else {}
 
                 results.append(experiment_result)
 
@@ -366,9 +371,14 @@ class QuantinuumJob(JobV1):
                 'job_id': self._job_ids[i]
             }
             if self._circuits_job:
-                experiment_result['header'] = {} if self._experiments[i].metadata is None else self._experiments[i].metadata
+                if self._experiments[i].metadata is None:
+                    metadata = {}
+                else:
+                    metadata = self._experiments[i].metadata
+                experiment_result['header'] = metadata
             else:
-                experiment_result['header'] = self._qobj_payload['experiments'][i]['header'] if self._qobj_payload else {}
+                experiment_result['header'] = self._qobj_payload[
+                    'experiments'][i]['header'] if self._qobj_payload else {}
 
             results.append(experiment_result)
 

--- a/qiskit_quantinuum/quantinuumjob.py
+++ b/qiskit_quantinuum/quantinuumjob.py
@@ -353,7 +353,6 @@ class QuantinuumJob(JobV1):
                 else:
                     experiment_result['header'] = self._qobj_payload[
                     'experiments'][i]['header'] if self._qobj_payload else {}
-
                 results.append(experiment_result)
 
                 continue
@@ -379,7 +378,6 @@ class QuantinuumJob(JobV1):
             else:
                 experiment_result['header'] = self._qobj_payload[
                     'experiments'][i]['header'] if self._qobj_payload else {}
-
             results.append(experiment_result)
 
         result = {

--- a/qiskit_quantinuum/quantinuumjob.py
+++ b/qiskit_quantinuum/quantinuumjob.py
@@ -336,7 +336,24 @@ class QuantinuumJob(JobV1):
         for i, res_resp in enumerate(self._experiment_results):
             if type(res_resp) is JobStatus:
                 self._status = res_resp
+
+                experiment_result = {
+                    'shots': self._job_config.get('shots', 1),
+                    'success': False,
+                    'data': {'counts': {}},
+                    'job_id': self._job_ids[i]
+                }
+
+                if self._circuits_job:
+                    experiment_result['header'] = {} if self._experiments[i].metadata is None
+                        else self._experiments[i].metadata
+                else:
+                    experiment_result['header'] =
+                        self._qobj_payload['experiments'][i]['header'] if self._qobj_payload else {}
+                results.append(experiment_result)
+
                 continue
+
             status = res_resp.get('status', 'failed')
             if status == 'failed':
                 self._status = JobStatus.ERROR
@@ -350,11 +367,8 @@ class QuantinuumJob(JobV1):
                 'job_id': self._job_ids[i]
             }
             if self._circuits_job:
-                if self._experiments[i].metadata is None:
-                    metadata = {}
-                else:
-                    metadata = self._experiments[i].metadata
-                experiment_result['header'] = metadata
+                experiment_result['header'] = {} if self._experiments[i].metadata is None
+                        else self._experiments[i].metadata
             else:
                 experiment_result['header'] = self._qobj_payload[
                     'experiments'][i]['header'] if self._qobj_payload else {}

--- a/qiskit_quantinuum/quantinuumjob.py
+++ b/qiskit_quantinuum/quantinuumjob.py
@@ -368,7 +368,7 @@ class QuantinuumJob(JobV1):
             }
             if self._circuits_job:
                 experiment_result['header'] = {} if self._experiments[i].metadata is None
-                        else self._experiments[i].metadata
+                    else self._experiments[i].metadata
             else:
                 experiment_result['header'] = self._qobj_payload[
                     'experiments'][i]['header'] if self._qobj_payload else {}

--- a/qiskit_quantinuum/quantinuumjob.py
+++ b/qiskit_quantinuum/quantinuumjob.py
@@ -334,7 +334,7 @@ class QuantinuumJob(JobV1):
         results = []
         self._status = JobStatus.DONE
         for i, res_resp in enumerate(self._experiment_results):
-            if type(res_resp) is JobStatus:
+            if isinstance(res_resp, JobStatus):
                 self._status = res_resp
 
                 experiment_result = {
@@ -352,7 +352,7 @@ class QuantinuumJob(JobV1):
                     experiment_result['header'] = metadata
                 else:
                     experiment_result['header'] = self._qobj_payload[
-                    'experiments'][i]['header'] if self._qobj_payload else {}
+                        'experiments'][i]['header'] if self._qobj_payload else {}
                 results.append(experiment_result)
 
                 continue

--- a/qiskit_quantinuum/quantinuumjob.py
+++ b/qiskit_quantinuum/quantinuumjob.py
@@ -336,7 +336,7 @@ class QuantinuumJob(JobV1):
         for i, res_resp in enumerate(self._experiment_results):
             if type(res_resp) is JobStatus:
                 self._status = res_resp
-                break
+                continue
             status = res_resp.get('status', 'failed')
             if status == 'failed':
                 self._status = JobStatus.ERROR

--- a/qiskit_quantinuum/quantinuumjob.py
+++ b/qiskit_quantinuum/quantinuumjob.py
@@ -345,7 +345,7 @@ class QuantinuumJob(JobV1):
                 }
 
                 if self._circuits_job:
-                    if len(self._experiments) >= i or self._experiments[i].metadata is None:
+                    if len(self._experiments) <= i or self._experiments[i].metadata is None:
                         metadata = {}
                     else:
                         metadata = self._experiments[i].metadata

--- a/qiskit_quantinuum/quantinuumjob.py
+++ b/qiskit_quantinuum/quantinuumjob.py
@@ -334,6 +334,9 @@ class QuantinuumJob(JobV1):
         results = []
         self._status = JobStatus.DONE
         for i, res_resp in enumerate(self._experiment_results):
+            if type(res_resp) is JobStatus:
+                self._status = res_resp
+                break
             status = res_resp.get('status', 'failed')
             if status == 'failed':
                 self._status = JobStatus.ERROR


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ (See details) ] I have added the tests to cover my changes.
- [ N/A ] I have updated the documentation accordingly.
- [ x ] I have read the CONTRIBUTING document.
-->

### Summary

(Closes #27)

Over at https://github.com/SRI-International/QC-App-Oriented-Benchmarks, we're trying to use this provider to benchmark Quantinuum devices. However, adding the provider to that repository, it always raises an exception due to an unhandled case in the method `status()`, where one or more items in `self._experiment_results` is a `JobStatus` instance.

Following your logic in the same region of code, we extract the maximum information we can for the `experiment_result`, then we add the header and append to the results list otherwise exactly according to how it was already done.

This fixes our issue in the benchmarks repository, allowing us to get the results we expect.

### Details and comments

For coverage: I can see that the original code leads to an exception and stack trace in https://github.com/SRI-International/QC-App-Oriented-Benchmarks, while the code is this branch works. I'm not sure how to encapsulate this in a unit test, but, apparently, the original code coverage didn't cover this logical case, of a `JobStatus` response.
