### PR TITLE
remove family submissions from example notebook

### DIFF
--- a/examples/QuantinuumExample.ipynb
+++ b/examples/QuantinuumExample.ipynb
@@ -49,21 +49,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Enter your password: ········\n",
-      "***Successfully logged in***\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Quantinuum.save_account(user_name=\"first.last@company.com\")\n",
-    "Quantinuum.save_account(user_name=\"megan.l.kohagen@quantinuum.com\")\n",
+    "Quantinuum.save_account(user_name=\"first.last@company.com\")\n",
     "Quantinuum.load_account()"
    ]
   },
@@ -126,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -154,7 +144,7 @@
        "                      0  1 "
       ]
      },
-     "execution_count": 5,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -347,32 +337,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Submit to a Machine Family\n",
-    "\n",
-    "If you would like faster access to hardware between the available quantum computers, you can submit to a Hardware Family. Submitting this way will run the job on whatever device is available first that has the number of qubits needed to run the circuit. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "device = 'H1'\n",
-    "shots = 100\n",
-    "\n",
-    "backend = Quantinuum.get_backend(device)\n",
-    "job = execute(circuit, backend, shots=shots)\n",
-    "\n",
-    "result = job.result()\n",
-    "counts = result.get_counts()\n",
-    "print(counts)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Recommended Workflow <a class=\"anchor\" id=\"recommended-workflow\"></a>\n",
     "\n",
     "Quantinuum provides device-specific syntax checkers and emulators in addition to quantum computing hardware. Quantum algorithm development takes a lot of time to create a quantum circuit, run on hardware, analyze results, and iterate. Within this loop it is common to go through multiple debugging cycles either due to code or circuit design. \n",
@@ -423,7 +387,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6 (tags/v3.10.6:9c7b4bd, Aug  1 2022, 21:53:49) [MSC v.1932 64 bit (AMD64)]"
+   "version": "3.10.11"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
### Summary

Phasing out submission to machine families (ex. H1 vs. H1-1) in favor of submitting only to specific machines, so removed that example from the example notebook. 


### Details and comments


